### PR TITLE
Add support for parent centers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 
+## Centros
+
+Los centros pueden organizarse en una jerarquía. Un centro puede definirse como
+"padre" de otros centros, creando así grupos de clientes. Los centros que
+actúan como padre no pueden tener POF asignados y se usan únicamente como
+contenedores de otros centros.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/app/actions/createCenter.ts
+++ b/app/actions/createCenter.ts
@@ -14,6 +14,7 @@ const schema = z.object({
   contactName: z.string(),
   contactPhone: z.string(),
   contactEmail: z.string().email().optional(),
+  parentCenterId: z.string().optional(),
   notes: z.string().optional(),
 });
 

--- a/app/actions/updateCenter.ts
+++ b/app/actions/updateCenter.ts
@@ -15,6 +15,7 @@ const schema = z.object({
   contactName: z.string(),
   contactPhone: z.string(),
   contactEmail: z.string().email().optional(),
+  parentCenterId: z.string().optional(),
   notes: z.string().optional(),
 });
 
@@ -33,6 +34,7 @@ export async function updateCenter(input: z.infer<typeof schema>) {
       contactName: data.contactName,
       contactPhone: data.contactPhone,
       contactEmail: data.contactEmail,
+      parentCenterId: data.parentCenterId,
       notes: data.notes,
     },
   });

--- a/app/api/centers/route.ts
+++ b/app/api/centers/route.ts
@@ -1,9 +1,11 @@
 // app/api/centers/route.ts
 import { db } from "@/lib/db";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const all = req.nextUrl.searchParams.get("all");
   const centers = await db.center.findMany({
+    where: all ? undefined : { subCenters: { none: {} } },
     orderBy: { name: "asc" },
   });
 

--- a/components/centers/forms/EditCenterForm.tsx
+++ b/components/centers/forms/EditCenterForm.tsx
@@ -5,7 +5,15 @@ import { z } from "zod";
 import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Center } from "@prisma/client";
+import { useEffect, useState } from "react";
 import { updateCenter } from "@/app/actions/updateCenter";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -22,6 +30,7 @@ const formSchema = z.object({
   contactName: z.string(),
   contactPhone: z.string(),
   contactEmail: z.string().email().optional(),
+  parentCenterId: z.string().optional(),
   notes: z.string().optional(),
 });
 
@@ -32,10 +41,18 @@ interface Props {
 
 export function EditCenterForm({ center, onSuccess }: Props) {
   const router = useRouter();
+  const [centers, setCenters] = useState<Center[]>([]);
+
+  useEffect(() => {
+    fetch("/api/centers?all=true")
+      .then((res) => res.json())
+      .then(setCenters);
+  }, []);
 
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors, isSubmitting },
   } = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -50,6 +67,7 @@ export function EditCenterForm({ center, onSuccess }: Props) {
       contactName: center.contactName,
       contactPhone: center.contactPhone,
       contactEmail: center.contactEmail ?? "",
+      parentCenterId: center.parentCenterId ?? "",
       notes: center.notes ?? "",
     },
   });
@@ -112,6 +130,22 @@ export function EditCenterForm({ center, onSuccess }: Props) {
       <div>
         <Label htmlFor="contactEmail">Email</Label>
         <Input id="contactEmail" {...register("contactEmail")} />
+      </div>
+
+      <div>
+        <Label>Centro padre</Label>
+        <Select onValueChange={(v) => setValue("parentCenterId", v)} defaultValue={center.parentCenterId ?? undefined}>
+          <SelectTrigger>
+            <SelectValue placeholder="Sin centro padre" />
+          </SelectTrigger>
+          <SelectContent>
+            {centers.map((c) => (
+              <SelectItem key={c.id} value={c.id}>
+                {c.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       <div>

--- a/components/centers/forms/NewCenterForm.tsx
+++ b/components/centers/forms/NewCenterForm.tsx
@@ -9,7 +9,16 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 
+import { useEffect, useState } from "react";
 import { createCenter } from "@/app/actions/createCenter";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Center } from "@prisma/client";
 
 const formSchema = z.object({
   name: z.string().min(2),
@@ -21,20 +30,30 @@ const formSchema = z.object({
   contactName: z.string(),
   contactPhone: z.string(),
   contactEmail: z.string().email().optional(),
+  parentCenterId: z.string().optional(),
   notes: z.string().optional(),
 });
 
 export function NewCenterForm() {
   const router = useRouter();
+  const [centers, setCenters] = useState<Center[]>([]);
+
+  useEffect(() => {
+    fetch("/api/centers?all=true")
+      .then((res) => res.json())
+      .then(setCenters);
+  }, []);
 
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors, isSubmitting },
   } = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       country: "España",
+      parentCenterId: undefined,
     },
   });
 
@@ -93,6 +112,22 @@ export function NewCenterForm() {
       <div>
         <Label htmlFor="contactEmail">Email de contacto</Label>
         <Input id="contactEmail" {...register("contactEmail")} />
+      </div>
+
+      <div>
+        <Label>Centro padre</Label>
+        <Select onValueChange={(v) => setValue("parentCenterId", v)}>
+          <SelectTrigger>
+            <SelectValue placeholder="Sin centro padre" />
+          </SelectTrigger>
+          <SelectContent>
+            {centers.map((center) => (
+              <SelectItem key={center.id} value={center.id}>
+                {center.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       <div>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,9 @@ model Center {
   name       String
   tenantId   String
   tenant     Tenant       @relation(fields: [tenantId], references: [id])
+  parentCenterId String?
+  parentCenter   Center?  @relation("CenterHierarchy", fields: [parentCenterId], references: [id])
+  subCenters     Center[] @relation("CenterHierarchy")
   pofs       POF[]
   invoices   Invoice[]
   users      CenterUser[]

--- a/types/center.type.ts
+++ b/types/center.type.ts
@@ -3,3 +3,7 @@ import { Center, POF } from "@prisma/client";
 export type CenterWithPofs = Center & {
   pofs: POF[];
 };
+
+export type CenterWithChildren = Center & {
+  subCenters: Center[];
+};


### PR DESCRIPTION
## Summary
- allow defining a parent center when creating or editing centers
- update API route to filter out parent centers unless explicitly requested
- document center hierarchy support
- extend prisma schema and types with center hierarchy

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a77a697c8332b2048ef7e6ac32bf