### PR TITLE
Move machine details into POF pages

### DIFF
--- a/app/(routes)/pofs/[id]/page.tsx
+++ b/app/(routes)/pofs/[id]/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { useState, useEffect } from "react";
+import { PofInfo } from "@/components/pofs/detail/PofInfo";
+import { MachineInfo } from "@/components/machines/detail/MachineInfo";
+import { MachineDetailsTabs } from "@/components/machines/detail/MachineDetailsTabs";
+import { EditMachineModal } from "@/components/machines/forms/EditMachineModal";
+import { PofWithMachineDetails } from "@/types";
+
+async function fetchPofData(id: string): Promise<PofWithMachineDetails> {
+  const res = await fetch(`/api/pofs/${id}`);
+  if (!res.ok) {
+    throw new Error("Error fetching POF data");
+  }
+  return res.json();
+}
+
+export default function PofDetailPage({ params }: { params: { id: string } }) {
+  const [pof, setPof] = useState<PofWithMachineDetails | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  useEffect(() => {
+    fetchPofData(params.id)
+      .then(setPof)
+      .catch((err) => console.error(err));
+  }, [params.id]);
+
+  const openEditModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+
+  const refreshData = async () => {
+    const updated = await fetchPofData(params.id);
+    setPof(updated);
+  };
+
+  return (
+    <div className="p-6 space-y-8">
+      <h2 className="text-2xl font-bold">Detalle de POF</h2>
+      {pof && (
+        <>
+          <PofInfo pof={pof} />
+          {pof.machine && (
+            <>
+              <MachineInfo machine={pof.machine} onEdit={openEditModal} />
+              <MachineDetailsTabs machine={pof.machine} />
+              <EditMachineModal
+                machine={pof.machine}
+                open={isModalOpen}
+                onClose={async () => {
+                  closeModal();
+                  await refreshData();
+                }}
+                onSuccess={async () => {
+                  closeModal();
+                  await refreshData();
+                }}
+              />
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/api/pofs/[id]/route.ts
+++ b/app/api/pofs/[id]/route.ts
@@ -1,0 +1,34 @@
+import { db } from "@/lib/db";
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const pof = await db.pOF.findUnique({
+      where: { id: params.id },
+      include: {
+        center: true,
+        machine: {
+          include: {
+            pof: true,
+            products: {
+              include: { product: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!pof) {
+      return new Response("POF not found", { status: 404 });
+    }
+
+    return new Response(JSON.stringify(pof), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching POF:", error);
+    return new Response("Error fetching POF", { status: 500 });
+  }
+}

--- a/components/pofs/columns.tsx
+++ b/components/pofs/columns.tsx
@@ -3,6 +3,9 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { POF } from "@prisma/client";
 import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
+import { Eye } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { EditPofModal } from "./forms/EditPofModal";
 import { PofWithCenter } from "@/types";
 
@@ -10,9 +13,19 @@ export const columns: ColumnDef<PofWithCenter>[] = [
   {
     accessorKey: "name",
     header: "Nombre",
-    cell: ({ row }) => (
-      <span className="font-medium">{row.getValue("name")}</span>
-    ),
+    cell: ({ row }) => {
+      const pof = row.original;
+      return (
+        <div className="flex items-center gap-2 justify-between">
+          <span className="font-medium">{row.getValue("name")}</span>
+          <Link href={`/pofs/${pof.id}`}>
+            <Button variant="ghost" size="icon">
+              <Eye className="w-4 h-4" />
+            </Button>
+          </Link>
+        </div>
+      );
+    },
   },
   {
     accessorKey: "city",

--- a/components/pofs/detail/PofInfo.tsx
+++ b/components/pofs/detail/PofInfo.tsx
@@ -1,0 +1,33 @@
+import { POF, Center } from "@prisma/client";
+
+interface Props {
+  pof: POF & { center: Center };
+}
+
+export function PofInfo({ pof }: Props) {
+  return (
+    <div className="grid md:grid-cols-2 gap-6 bg-background rounded-lg p-4 border">
+      <div>
+        <p className="text-sm text-muted-foreground">Nombre</p>
+        <p className="font-medium">{pof.name}</p>
+      </div>
+      <div>
+        <p className="text-sm text-muted-foreground">Centro</p>
+        <p>{pof.center.name}</p>
+      </div>
+      <div>
+        <p className="text-sm text-muted-foreground">Dirección</p>
+        <p>
+          {pof.address}, {pof.city}
+        </p>
+      </div>
+      <div>
+        <p className="text-sm text-muted-foreground">Contacto</p>
+        <p>
+          {pof.contactName || "-"}
+          {pof.contactPhone ? ` (${pof.contactPhone})` : ""}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/types/pof.type.ts
+++ b/types/pof.type.ts
@@ -1,8 +1,13 @@
-import { POF, Machine, Center } from "@prisma/client";
+import { POF, Machine, MachineProduct, Product, Center } from "@prisma/client";
 
 export type PofWithMachines = POF & {
   center: Center;
   machine: Machine | null;
+};
+
+export type PofWithMachineDetails = POF & {
+  center: Center;
+  machine: (Machine & { products: (MachineProduct & { product: Product })[] }) | null;
 };
 
 export type PofWithCenter = POF & {


### PR DESCRIPTION
## Summary
- add API route to fetch a POF with its machine and stock
- add `PofInfo` component
- create dynamic POF detail page that displays machine details
- export new `PofWithMachineDetails` type
- link to POF detail page from POF table

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b3ccc8ac8332b87f0ff6478da6bf