### PR TITLE
Update remaining POS references to PDV

### DIFF
--- a/app/(routes)/pdvs/page.tsx
+++ b/app/(routes)/pdvs/page.tsx
@@ -3,7 +3,7 @@ import { PdvTable } from "@/components/pdv/PdvTable";
 import { NewPdvModal } from "@/components/pdv/forms/NewPdvModal";
 
 export default async function PdvPage() {
-  const pdvList = await db.pOS.findMany({
+  const pdvList = await db.pDV.findMany({
     orderBy: { createdAt: "desc" },
     include: {
       center: true, // Para poder ver a qué centro pertenece cada PDV

--- a/app/actions/createPdv.ts
+++ b/app/actions/createPdv.ts
@@ -20,7 +20,7 @@ interface CreatePdvInput {
 }
 
 export async function createPdv(data: CreatePdvInput) {
-  await db.pOS.create({
+  await db.pDV.create({
     data: {
       code: data.code,
       name: data.name,

--- a/app/actions/updatePdv.ts
+++ b/app/actions/updatePdv.ts
@@ -20,7 +20,7 @@ const schema = z.object({
 export async function updatePdv(input: z.infer<typeof schema>) {
   const values = schema.parse(input);
 
-  await db.pos.update({
+  await db.pDV.update({
     where: { id: values.id },
     data: {
       name: values.name,

--- a/app/api/pdvs/[id]/route.ts
+++ b/app/api/pdvs/[id]/route.ts
@@ -5,7 +5,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    const pdv = await db.pOS.findUnique({
+    const pdv = await db.pDV.findUnique({
       where: { id: params.id },
       include: {
         center: true,

--- a/app/api/pdvs/route.ts
+++ b/app/api/pdvs/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 
 export async function GET() {
   try {
-    const pdvList = await db.pOS.findMany({
+    const pdvList = await db.pDV.findMany({
       where: {
         active: true,
       },

--- a/app/api/sales/route.ts
+++ b/app/api/sales/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: NextRequest) {
   try {
     const data = saleSchema.parse(await req.json());
 
-    const pdv = await db.pOS.findFirst({
+    const pdv = await db.pDV.findFirst({
       where: { code: data.pdvCode },
     });
 

--- a/components/centers/columns.tsx
+++ b/components/centers/columns.tsx
@@ -57,8 +57,8 @@ export const columns: ColumnDef<CenterChild>[] = [
     },
   },
   {
-    id: "posCount",
-    header: "POS activos",
+    id: "pdvCount",
+    header: "PDVs activos",
     cell: ({ row }) => row.original.pos.length,
   },
   {

--- a/components/machines/detail/MachineDetailsTabs.tsx
+++ b/components/machines/detail/MachineDetailsTabs.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Machine, MachineProduct, Product, POS } from "@prisma/client";
+import { Machine, MachineProduct, Product, PDV } from "@prisma/client";
 import { MachineStockTable } from "@/components/machines/detail/stock/MachineStockTable"; // Stock
 import { MaintenanceHistoryTable } from "@/components/machines/detail/MaintenanceHistoryTable"; // Mantenimiento
 import { MachineSalesTable } from "@/components/machines/detail/sales/MachineSalesTable"; // Ventas
 import { Button } from "@/components/ui/button";
 
 export interface MachineWithProducts extends Machine {
-  pos: POS | null;
+  pos: PDV | null;
   products: (MachineProduct & { product: Product })[];
 }
 
@@ -30,7 +30,7 @@ export function MachineDetailsTabs({ machine }: Props) {
         return machine.pos ? (
           <MachineSalesTable posId={machine.pos.id} />
         ) : (
-          <div>No POS asociado</div>
+          <div>No PDV asociado</div>
         );
       default:
         return <div>Selecciona una sección.</div>;

--- a/components/machines/detail/MachineInfo.tsx
+++ b/components/machines/detail/MachineInfo.tsx
@@ -1,11 +1,11 @@
-import { Machine, POS, MachineStatus, MachineType } from "@prisma/client";
+import { Machine, PDV, MachineStatus, MachineType } from "@prisma/client";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Pencil } from "lucide-react";
 //import { EditMachineModal } from "@/components/machines/forms/EditMachineModal";
 
 interface Props {
-  machine: Machine & { pos: POS | null };
+  machine: Machine & { pos: PDV | null };
   onEdit: (machine: Machine) => void; // Función para abrir el modal
 }
 
@@ -60,7 +60,7 @@ export function MachineInfo({ machine, onEdit }: Props) {
       </div>
 
       <div>
-        <p className="text-sm text-muted-foreground">POS</p>
+        <p className="text-sm text-muted-foreground">PDV</p>
         <p>{machine.pos?.name ?? "–"}</p>
       </div>
 

--- a/components/machines/forms/NewMachineForm.tsx
+++ b/components/machines/forms/NewMachineForm.tsx
@@ -178,9 +178,9 @@ export function NewMachineForm() {
               <SelectValue placeholder="Selecciona PDV" />
             </SelectTrigger>
             <SelectContent>
-              {filteredPdvs.map((pos) => (
-                <SelectItem key={pos.id} value={pos.id}>
-                  {pos.name}
+              {filteredPdvs.map((pdv) => (
+                <SelectItem key={pdv.id} value={pdv.id}>
+                  {pdv.name}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/components/masters/detail/MasterInfo.tsx
+++ b/components/masters/detail/MasterInfo.tsx
@@ -1,4 +1,4 @@
-import { Master, POS as PDV, Tenant } from "@prisma/client";
+import { Master, PDV, Tenant } from "@prisma/client";
 
 interface Props {
   master: Master & { pos: PDV | null; tenant: Tenant };

--- a/components/pdv/detail/PdvInfo.tsx
+++ b/components/pdv/detail/PdvInfo.tsx
@@ -1,4 +1,4 @@
-import { POS as PDV, Center, Master } from "@prisma/client";
+import { PDV, Center, Master } from "@prisma/client";
 import { Button } from "@/components/ui/button";
 import { Pencil } from "lucide-react";
 

--- a/components/pdv/forms/EditPdvForm.tsx
+++ b/components/pdv/forms/EditPdvForm.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { POS as PDV } from "@prisma/client";
+import { PDV } from "@prisma/client";
 import { updatePdv } from "@/app/actions/updatePdv"; // Asegúrate de tener esta acción creada
 
 import { Input } from "@/components/ui/input";

--- a/components/pdv/forms/EditPdvModal.tsx
+++ b/components/pdv/forms/EditPdvModal.tsx
@@ -8,7 +8,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { EditPdvForm } from "./EditPdvForm";
-import { POS as PDV, Center } from "@prisma/client";
+import { PDV, Center } from "@prisma/client";
 import { Button } from "@/components/ui/button";
 import { Pencil } from "lucide-react";
 import { useState } from "react";

--- a/components/pdv/pdvColumns.tsx
+++ b/components/pdv/pdvColumns.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
-import { POS as PDV } from "@prisma/client";
+import { PDV } from "@prisma/client";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 import { Eye } from "lucide-react";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,7 @@ model User {
   maintenance  MaintenanceLog[]
   activityLogs ActivityLog[]
   centers      CenterUser[]
-  pos          POSUser[]
+  pos          PDVUser[]
 }
 
 model Tenant {
@@ -47,12 +47,12 @@ model CenterUser {
   center   Center @relation(fields: [centerId], references: [id])
 }
 
-model POSUser {
+model PDVUser {
   id     String @id @default(uuid())
   userId String
   posId  String
   user   User   @relation(fields: [userId], references: [id])
-  pos    POS    @relation(fields: [posId], references: [id])
+  pos    PDV    @relation(fields: [posId], references: [id])
 }
 
 enum Role {
@@ -61,7 +61,7 @@ enum Role {
   TENANT_USER
   CENTER_MANAGER
   CENTER_USER
-  POS_USER
+  PDV_USER
 }
 
 //
@@ -85,7 +85,7 @@ model Center {
   updatedAt      DateTime     @updatedAt
   tenantId       String
   tenant         Tenant       @relation(fields: [tenantId], references: [id])
-  pos            POS[]
+  pos            PDV[]
   invoices       Invoice[]
   users          CenterUser[]
   parentCenterId String?
@@ -94,7 +94,7 @@ model Center {
   Machine        Machine[]
 }
 
-model POS {
+model PDV {
   id           String    @id @default(uuid())
   code         String    @unique
   name         String
@@ -110,7 +110,7 @@ model POS {
   centerId     String
   center       Center    @relation(fields: [centerId], references: [id])
   machine      Machine?
-  users        POSUser[]
+  users        PDVUser[]
   master       Master?
   active       Boolean   @default(true)
   createdAt    DateTime  @default(now())
@@ -124,7 +124,7 @@ model Master {
   tenantId     String
   tenant       Tenant   @relation(fields: [tenantId], references: [id])
   posId        String?  @unique
-  pos          POS?     @relation(fields: [posId], references: [id])
+  pos          PDV?     @relation(fields: [posId], references: [id])
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 }
@@ -147,7 +147,7 @@ model Machine {
   center       Center        @relation(fields: [centerId], references: [id])
 
   posId String? @unique
-  pos   POS?    @relation(fields: [posId], references: [id])
+  pos   PDV?    @relation(fields: [posId], references: [id])
 
   products       MachineProduct[]
   maintenanceLog MaintenanceLog[]
@@ -336,7 +336,7 @@ model Sale {
   change    Float
   timestamp DateTime   @default(now())
 
-  pos       POS      @relation(fields: [posId], references: [id])
+  pos       PDV      @relation(fields: [posId], references: [id])
   product   Product  @relation(fields: [productId], references: [id])
   Machine   Machine? @relation(fields: [machineId], references: [id])
   machineId String?

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -66,10 +66,10 @@ async function main() {
         });
 
         for (let p = 0; p < 2; p++) {
-          const pos = await prisma.pOS.create({
+          const pdv = await prisma.pDV.create({
             data: {
               code: `T${t + 1}C${c + 1}S${s + 1}P${p + 1}`,
-              name: `POS ${p + 1}`,
+              name: `PDV ${p + 1}`,
               address: faker.location.streetAddress(),
               city: faker.location.city(),
               centerId: subCenter.id,
@@ -80,7 +80,7 @@ async function main() {
             data: {
               serialNumber: faker.string.alphanumeric(12),
               tenantId: tenant.id,
-              posId: pos.id,
+              posId: pdv.id,
             },
           });
 
@@ -91,7 +91,7 @@ async function main() {
               serialNumber: faker.string.alphanumeric(10),
               type: "SNACK",
               centerId: subCenter.id,
-              posId: pos.id,
+              posId: pdv.id,
               status: "ACTIVE",
               installedAt: faker.date.past(),
             },

--- a/types/center.type.ts
+++ b/types/center.type.ts
@@ -1,4 +1,4 @@
-import { Center, POS as PDV } from "@prisma/client";
+import { Center, PDV } from "@prisma/client";
 export type CenterWithPdv = Center & {
   pdvs: PDV[];
 };

--- a/types/machine.type.ts
+++ b/types/machine.type.ts
@@ -3,7 +3,7 @@ import {
   MachineProduct,
   Product,
   Center,
-  POS as PDV,
+  PDV,
 } from "@prisma/client";
 
 export type MachineWithDetails = Machine & {

--- a/types/master.type.ts
+++ b/types/master.type.ts
@@ -1,4 +1,4 @@
-import { Master, POS as PDV, Tenant } from "@prisma/client";
+import { Master, PDV, Tenant } from "@prisma/client";
 
 export type MasterWithRelations = Master & {
   tenant: Tenant;

--- a/types/pdv.type.ts
+++ b/types/pdv.type.ts
@@ -1,5 +1,5 @@
 import {
-  POS as PDV,
+  PDV,
   Machine,
   MachineProduct,
   Product,

--- a/types/sale.type.ts
+++ b/types/sale.type.ts
@@ -1,4 +1,4 @@
-import { Sale, Product, POS as PDV } from "@prisma/client";
+import { Sale, Product, PDV } from "@prisma/client";
 
 export type SaleWithDetails = Sale & {
   pos: PDV;


### PR DESCRIPTION
## Summary
- rename Prisma model `POS` to `PDV`
- adjust seed script and API calls for `pDV`
- update imports and variables to use `PDV`
- fix labels referencing PDV in forms

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da42b573c83329aad385a84a56018