### PR TITLE
Add multilingual support

### DIFF
--- a/app/auth/layout.tsx
+++ b/app/auth/layout.tsx
@@ -1,10 +1,12 @@
 import { Logo } from "@/components/layout/Logo";
+import { useTranslations } from "next-intl";
 
 export default function LayoutAuth({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const t = useTranslations("AuthLayout");
   return (
     <div className="min-h-screen flex flex-col items-center text-center justify-center bg-background px-4">
       <div className="w-full max-w-sm space-y-6">
@@ -12,7 +14,7 @@ export default function LayoutAuth({
           <Logo />
         </div>
         <h1 className="text-2xl font-semibold text-foreground">
-          Welcome to VendCore!
+          {t("welcome")}
         </h1>
         {children}
       </div>

--- a/components/layout/LocaleSwitcher.tsx
+++ b/components/layout/LocaleSwitcher.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useLocale, usePathname } from "next-intl";
+import Link from "next-intl/link";
+
+export function LocaleSwitcher() {
+  const locale = useLocale();
+  const pathname = usePathname();
+
+  return (
+    <div className="flex items-center gap-1 text-sm">
+      <Link href={pathname} locale="en" className={locale === "en" ? "font-semibold underline" : ""}>
+        EN
+      </Link>
+      <span>|</span>
+      <Link href={pathname} locale="es" className={locale === "es" ? "font-semibold underline" : ""}>
+        ES
+      </Link>
+    </div>
+  );
+}

--- a/components/layout/Navbar/Navbar.tsx
+++ b/components/layout/Navbar/Navbar.tsx
@@ -6,9 +6,12 @@ import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { ToggleTheme } from "@/components/ui/ToggleTheme";
 import { SidebarRoutes } from "../SidebarRoutes";
 import { Button } from "@/components/ui/button";
+import { useTranslations } from "next-intl";
+import { LocaleSwitcher } from "../LocaleSwitcher";
 
 export function Navbar() {
   const { data: session } = useSession();
+  const t = useTranslations("Navbar");
   return (
     <nav className="flex items-center px-2 gap-x-4 md:px-6 justify-between w-full bg-background border-b h-20">
       <div className="block xl:hidden">
@@ -22,7 +25,7 @@ export function Navbar() {
         </Sheet>
       </div>
       <div className="relative w-[300px]">
-        <Input placeholder="Search..." className="rounded-lg" />
+        <Input placeholder={t("searchPlaceholder")} className="rounded-lg" />
         <Search strokeWidth={1} className="absolute top-2 right-2" />
       </div>
       {session?.user?.tenant?.name ? (
@@ -32,9 +35,10 @@ export function Navbar() {
       ) : null}
       <div className="flex gap-x-2 items-center">
         <ToggleTheme />
+        <LocaleSwitcher />
         {session?.user ? (
           <Button variant="ghost" onClick={() => signOut()}>
-            Sign out
+            {t("signOut")}
           </Button>
         ) : null}
       </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,5 +4,12 @@
     "email": "Email",
     "password": "Password",
     "submit": "Enter"
+  },
+  "AuthLayout": {
+    "welcome": "Welcome to VendCore!"
+  },
+  "Navbar": {
+    "searchPlaceholder": "Search...",
+    "signOut": "Sign out"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -4,5 +4,12 @@
     "email": "Email",
     "password": "Contraseña",
     "submit": "Entrar"
+  },
+  "AuthLayout": {
+    "welcome": "Bienvenido a VendCore!"
+  },
+  "Navbar": {
+    "searchPlaceholder": "Buscar...",
+    "signOut": "Cerrar sesión"
   }
 }


### PR DESCRIPTION
## Summary
- expand message catalogs for English and Spanish
- translate authentication layout and navbar
- add locale switcher component

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e971d1d2c8332b36291ab6368828c