### PR TITLE
Fix tenant-specific data visibility

### DIFF
--- a/app/(routes)/centers/page.tsx
+++ b/app/(routes)/centers/page.tsx
@@ -1,12 +1,19 @@
 import { db } from "@/lib/db";
+import { getServerAuthSession } from "@/lib/auth";
 import { CenterTable } from "@/components/centers/CenterTable";
 import { ParentCenterTable } from "@/components/centers/ParentCenterTable";
 import { NewCenterModal } from "@/components/centers/forms/NewCenterModal";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 export default async function CentersPage() {
+  const session = await getServerAuthSession();
+  const tenantId = session?.user?.tenant?.id;
+
   const centers = await db.center.findMany({
-    where: { subCenters: { none: {} } },
+    where: {
+      tenantId,
+      subCenters: { none: {} },
+    },
     orderBy: { name: "desc" },
     include: {
       parentCenter: { select: { name: true } },
@@ -15,7 +22,10 @@ export default async function CentersPage() {
   });
 
   const parentCenters = await db.center.findMany({
-    where: { subCenters: { some: {} } },
+    where: {
+      tenantId,
+      subCenters: { some: {} },
+    },
     orderBy: { name: "desc" },
     include: {
       subCenters: { where: { active: true }, select: { id: true } },

--- a/app/(routes)/machines/page.tsx
+++ b/app/(routes)/machines/page.tsx
@@ -1,9 +1,14 @@
 import { db } from "@/lib/db";
+import { getServerAuthSession } from "@/lib/auth";
 import { MachineTable } from "@/components/machines/MachineTable";
 import { NewMachineModal } from "@/components/machines/forms/NewMachineModal";
 
 export default async function MachinesPage() {
+  const session = await getServerAuthSession();
+  const tenantId = session?.user?.tenant?.id;
+
   const machines = await db.machine.findMany({
+    where: { center: { tenantId } },
     include: {
       pos: {
         select: {

--- a/app/(routes)/pos/page.tsx
+++ b/app/(routes)/pos/page.tsx
@@ -1,9 +1,14 @@
 import { db } from "@/lib/db";
+import { getServerAuthSession } from "@/lib/auth";
 import { PosTable } from "@/components/pos/PosTable";
 import { NewPosModal } from "@/components/pos/forms/NewPosModal";
 
 export default async function PosPage() {
+  const session = await getServerAuthSession();
+  const tenantId = session?.user?.tenant?.id;
+
   const posList = await db.pOS.findMany({
+    where: { center: { tenantId } },
     orderBy: { createdAt: "desc" },
     include: {
       center: true,

--- a/app/api/centers/[id]/route.ts
+++ b/app/api/centers/[id]/route.ts
@@ -1,12 +1,16 @@
 import { db } from "@/lib/db";
+import { getServerAuthSession } from "@/lib/auth";
 
 export async function GET(
   request: Request,
   { params }: { params: { id: string } }
 ) {
   try {
-    const center = await db.center.findUnique({
-      where: { id: params.id },
+    const session = await getServerAuthSession();
+    const tenantId = session?.user?.tenant?.id;
+
+    const center = await db.center.findFirst({
+      where: { id: params.id, tenantId },
       include: {
         pos: {
           include: {

--- a/app/api/centers/route.ts
+++ b/app/api/centers/route.ts
@@ -1,11 +1,19 @@
 // app/api/centers/route.ts
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
+import { getServerAuthSession } from "@/lib/auth";
 
 export async function GET(req: NextRequest) {
+  const session = await getServerAuthSession();
+  const tenantId = session?.user?.tenant?.id;
+  if (!tenantId) return NextResponse.json([], { status: 401 });
+
   const all = req.nextUrl.searchParams.get("all");
   const centers = await db.center.findMany({
-    where: all ? undefined : { subCenters: { none: {} } },
+    where: {
+      tenantId,
+      ...(all ? {} : { subCenters: { none: {} } }),
+    },
     orderBy: { name: "asc" },
   });
 

--- a/app/api/machines/[id]/route.ts
+++ b/app/api/machines/[id]/route.ts
@@ -1,12 +1,16 @@
 import { db } from "@/lib/db";
+import { getServerAuthSession } from "@/lib/auth";
 
 export async function GET(
   request: Request,
   { params }: { params: { id: string } }
 ) {
   try {
-    const machine = await db.machine.findUnique({
-      where: { id: params.id },
+    const session = await getServerAuthSession();
+    const tenantId = session?.user?.tenant?.id;
+
+    const machine = await db.machine.findFirst({
+      where: { id: params.id, center: { tenantId } },
       include: {
         pos: true,
         center: true,

--- a/app/api/masters/[id]/route.ts
+++ b/app/api/masters/[id]/route.ts
@@ -1,9 +1,13 @@
 import { db } from "@/lib/db";
+import { getServerAuthSession } from "@/lib/auth";
 
 export async function GET(request: Request, { params }: { params: { id: string } }) {
   try {
-    const master = await db.master.findUnique({
-      where: { id: params.id },
+    const session = await getServerAuthSession();
+    const tenantId = session?.user?.tenant?.id;
+
+    const master = await db.master.findFirst({
+      where: { id: params.id, tenantId },
       include: { pos: true, tenant: true },
     });
 

--- a/app/api/metrics/sales/route.ts
+++ b/app/api/metrics/sales/route.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
+import { getServerAuthSession } from "@/lib/auth";
 import { format, subDays, subWeeks, subMonths, subYears, startOfWeek, startOfMonth, startOfYear } from "date-fns";
 
 export async function GET(req: NextRequest) {
@@ -30,8 +31,11 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "Invalid group" }, { status: 400 });
   }
 
+  const session = await getServerAuthSession();
+  const tenantId = session?.user?.tenant?.id;
+
   const sales = await db.sale.findMany({
-    where: { timestamp: { gte: start } },
+    where: { timestamp: { gte: start }, pos: { center: { tenantId } } },
   });
 
   const map: Record<string, { label: string; coins: number; cards: number }> = {};

--- a/app/api/pos/[id]/route.ts
+++ b/app/api/pos/[id]/route.ts
@@ -1,12 +1,16 @@
 import { db } from "@/lib/db";
+import { getServerAuthSession } from "@/lib/auth";
 
 export async function GET(
   request: Request,
   { params }: { params: { id: string } }
 ) {
   try {
-    const pos = await db.pOS.findUnique({
-      where: { id: params.id },
+    const session = await getServerAuthSession();
+    const tenantId = session?.user?.tenant?.id;
+
+    const pos = await db.pOS.findFirst({
+      where: { id: params.id, center: { tenantId } },
       include: {
         center: true,
         master: true,

--- a/app/api/pos/route.ts
+++ b/app/api/pos/route.ts
@@ -1,11 +1,16 @@
 import { db } from "@/lib/db";
 import { NextResponse } from "next/server";
+import { getServerAuthSession } from "@/lib/auth";
 
 export async function GET() {
   try {
+    const session = await getServerAuthSession();
+    const tenantId = session?.user?.tenant?.id;
+
     const posList = await db.pOS.findMany({
       where: {
         active: true,
+        center: { tenantId },
       },
       include: {
         center: true,

--- a/app/api/sales/route.ts
+++ b/app/api/sales/route.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/db";
 import { NextRequest, NextResponse } from "next/server";
+import { getServerAuthSession } from "@/lib/auth";
 import { z } from "zod";
 import { SaleMethod } from "@prisma/client";
 
@@ -75,9 +76,14 @@ export async function POST(req: NextRequest) {
 
 export async function GET(req: NextRequest) {
   const posId = req.nextUrl.searchParams.get("posId");
+  const session = await getServerAuthSession();
+  const tenantId = session?.user?.tenant?.id;
 
   const sales = await db.sale.findMany({
-    where: posId ? { posId: posId } : undefined,
+    where: {
+      ...(posId ? { posId } : {}),
+      pos: { center: { tenantId } },
+    },
     include: { product: true },
     orderBy: { timestamp: "desc" },
   });

--- a/components/dashboard/MachineConnections/MachineConnections.tsx
+++ b/components/dashboard/MachineConnections/MachineConnections.tsx
@@ -2,10 +2,15 @@ import { CustomIcon } from "@/components/ui/CustomIcon"
 import { List } from "lucide-react"
 import { MachineTable } from "@/components/machines/MachineTable"
 import { db } from "@/lib/db"
+import { getServerAuthSession } from "@/lib/auth"
 
 
 export async function MachineConnections() {
+    const session = await getServerAuthSession()
+    const tenantId = session?.user?.tenant?.id
+
     const machines = await db.machine.findMany({
+        where: { center: { tenantId } },
         include: { pos: { select: { name: true } } },
         orderBy: { createdAt: "desc" },
         take: 5,

--- a/components/dashboard/RecentPos/LastCenters.tsx
+++ b/components/dashboard/RecentPos/LastCenters.tsx
@@ -3,12 +3,16 @@ import { Building } from "lucide-react";
 import { CustomIcon } from "@/components/ui/CustomIcon";
 import { CenterTable } from "@/components/centers/CenterTable";
 import { db } from "@/lib/db";
+import { getServerAuthSession } from "@/lib/auth";
 
 export async function RecentPos() {
+  const session = await getServerAuthSession();
+  const tenantId = session?.user?.tenant?.id;
+
   const centers = await db.center.findMany({
+    where: { tenantId, subCenters: { none: {} } },
     orderBy: { createdAt: "desc" },
     take: 5,
-    where: { subCenters: { none: {} } },
     include: {
       parentCenter: { select: { name: true } },
       pos: { where: { active: true }, select: { id: true } },


### PR DESCRIPTION
## Summary
- restrict center listing and parent center listing to user's tenant
- filter POS, machines and dashboard metrics by tenant
- limit data returned from API endpoints to the current tenant

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npx tsc -p tsconfig.json --noEmit` *(fails to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851a1da61508332bc1234b9b54c060d