### PR TITLE
Improve API responses and UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Database connection string
+DATABASE_URL=
+
+# Secret used by NextAuth
+NEXTAUTH_SECRET=
+
+# API key for device endpoints
+DEVICE_API_KEY=

--- a/app/(routes)/machines/[id]/page.tsx
+++ b/app/(routes)/machines/[id]/page.tsx
@@ -2,6 +2,9 @@
 import { useState, useEffect } from "react";
 import { MachineInfo } from "@/components/machines/detail/MachineInfo";
 import { EditMachineModal } from "@/components/machines/forms/EditMachineModal";
+import { Spinner } from "@/components/ui/spinner";
+import { toast } from "@/components/ui/use-toast";
+import { MachineWithDetails } from "@/types";
 //import { MachineDetailsTabs } from "@/components/machines/detail/MachineDetailsTabs";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
@@ -20,8 +23,9 @@ export default function MachineDetailPage({
 }: {
   params: { id: string };
 }) {
-  const [selectedMachine, setSelectedMachine] = useState<any | null>(null);
+  const [selectedMachine, setSelectedMachine] = useState<MachineWithDetails | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   // Fetch machine data on initial load or when the ID changes
   useEffect(() => {
@@ -30,7 +34,13 @@ export default function MachineDetailPage({
         const machine = await fetchMachineData(params.id);
         setSelectedMachine(machine);
       } catch (error) {
-        console.error(error);
+        toast({
+          variant: "destructive",
+          title: "Error",
+          description: "No se pudo cargar la máquina",
+        });
+      } finally {
+        setLoading(false);
       }
     }
 
@@ -38,7 +48,7 @@ export default function MachineDetailPage({
   }, [params.id]);
 
   // Open the Edit Machine Modal
-  const openEditModal = (machine: any) => {
+  const openEditModal = (machine: MachineWithDetails) => {
     setSelectedMachine(machine);
     setIsModalOpen(true);
   };
@@ -83,8 +93,12 @@ export default function MachineDetailPage({
         </Button>
         <h2 className="text-2xl font-bold">Detalle de máquina</h2>
       </div>
-
-      {selectedMachine && (
+      {loading && (
+        <div className="flex justify-center py-10">
+          <Spinner />
+        </div>
+      )}
+      {!loading && selectedMachine && (
         <>
           {/* Información básica de la máquina */}
           <MachineInfo machine={selectedMachine} onEdit={openEditModal} />

--- a/app/(routes)/masters/[id]/page.tsx
+++ b/app/(routes)/masters/[id]/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 import { useState, useEffect } from "react";
 import { MasterInfo } from "@/components/masters/detail/MasterInfo";
+import { Spinner } from "@/components/ui/spinner";
+import { toast } from "@/components/ui/use-toast";
+import { MasterWithRelations } from "@/types";
 
 async function fetchMasterData(id: string) {
   const res = await fetch(`/api/masters/${id}`);
@@ -15,18 +18,31 @@ export default function MasterDetailPage({
 }: {
   params: { id: string };
 }) {
-  const [master, setMaster] = useState<any | null>(null);
+  const [master, setMaster] = useState<MasterWithRelations | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     fetchMasterData(params.id)
       .then(setMaster)
-      .catch((err) => console.error(err));
+      .catch(() => {
+        toast({
+          variant: "destructive",
+          title: "Error",
+          description: "No se pudo cargar el master",
+        });
+      })
+      .finally(() => setLoading(false));
   }, [params.id]);
 
   return (
     <div className="p-6 space-y-8">
       <h2 className="text-2xl font-bold">Detalle de Master</h2>
-      {master && <MasterInfo master={master} />}
+      {loading && (
+        <div className="flex justify-center py-10">
+          <Spinner />
+        </div>
+      )}
+      {!loading && master && <MasterInfo master={master} />}
     </div>
   );
 }

--- a/app/actions/addMachineProduct.ts
+++ b/app/actions/addMachineProduct.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { z } from "zod";
+
+const schema = z.object({
+  machineId: z.string(),
+  productId: z.string(),
+  quantity: z.number().int().positive(),
+  price: z.number(),
+  line: z.string(),
+  selection: z.string(),
+});
+
+export async function addMachineProduct(input: z.infer<typeof schema>) {
+  const data = schema.parse(input);
+
+  await db.machine.update({
+    where: { id: data.machineId },
+    data: {
+      products: {
+        create: {
+          productId: data.productId,
+          currentStock: data.quantity,
+          maxCapacity: data.quantity,
+          minThreshold: 1,
+          line: data.line,
+          selection: data.selection,
+          price: data.price,
+        },
+      },
+    },
+  });
+}

--- a/app/api/centers/[id]/route.ts
+++ b/app/api/centers/[id]/route.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/db";
 import { getServerAuthSession } from "@/lib/auth";
+import { ok, error, handleError } from "@/lib/apiResponses";
 
 export async function GET(
   request: Request,
@@ -29,7 +30,7 @@ export async function GET(
     });
 
     if (!center) {
-      return new Response("Center not found", { status: 404 });
+      return error("Center not found", 404);
     }
 
     const transformed = {
@@ -37,14 +38,8 @@ export async function GET(
       pos: center.pos.map((p) => ({ ...p, lastSale: p.Sale[0] || null })),
     };
 
-    return new Response(JSON.stringify(transformed), {
-      status: 200,
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+    return ok(transformed);
   } catch (error) {
-    console.error("Error fetching center:", error);
-    return new Response("Error fetching center", { status: 500 });
+    return handleError(error, "Error fetching center");
   }
 }

--- a/app/api/machines/[id]/route.ts
+++ b/app/api/machines/[id]/route.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/db";
 import { getServerAuthSession } from "@/lib/auth";
+import { ok, error, handleError } from "@/lib/apiResponses";
 
 export async function GET(
   request: Request,
@@ -23,16 +24,11 @@ export async function GET(
     });
 
     if (!machine) {
-      return new Response("Machine not found", { status: 404 });
+      return error("Machine not found", 404);
     }
 
-    return new Response(JSON.stringify(machine), {
-      status: 200,
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+    return ok(machine);
   } catch (error) {
-    return new Response("Error fetching machine data", { status: 500 });
+    return handleError(error, "Error fetching machine data");
   }
 }

--- a/components/machines/detail/stock/AddProductModal.tsx
+++ b/components/machines/detail/stock/AddProductModal.tsx
@@ -11,6 +11,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Product, Machine } from "@prisma/client";
+import { toast } from "@/components/ui/use-toast";
+import { addMachineProduct } from "@/app/actions/addMachineProduct";
 import {
   Dialog,
   DialogContent,
@@ -61,25 +63,23 @@ export function AddProductModal({
   const handleAddProduct = async () => {
     if (!selectedProduct || quantity <= 0 || !line || !selection) return;
 
-    const response = await fetch(`/api/machines/${machine.id}/add-product`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
+    try {
+      await addMachineProduct({
+        machineId: machine.id,
         productId: selectedProduct.id,
         quantity,
         price,
         line,
         selection,
-      }),
-    });
-
-    if (response.ok) {
+      });
       onSuccess();
       onClose();
-    } else {
-      console.error("Error al añadir el producto a la máquina");
+    } catch (err) {
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: "No se pudo añadir el producto",
+      });
     }
   };
 

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,0 +1,5 @@
+export function Spinner() {
+  return (
+    <div className="h-5 w-5 animate-spin rounded-full border-2 border-t-transparent border-primary" />
+  );
+}

--- a/lib/apiResponses.ts
+++ b/lib/apiResponses.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export function ok<T>(data: T, init: ResponseInit = {}) {
+  return NextResponse.json(data, init);
+}
+
+export function error(message: string, status = 500) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+export function handleError(err: unknown, message = "Internal Server Error") {
+  console.error(err);
+  return error(message, 500);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "@tanstack/react-table": "^8.16.0",
         "@uploadthing/react": "^6.4.4",
         "axios": "^1.6.8",
-        "bcrypt": "^6.0.0",
         "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
@@ -58,7 +57,6 @@
         "zod": "^3.23.3"
       },
       "devDependencies": {
-        "@types/bcrypt": "^5.0.2",
         "@types/bcryptjs": "^2.4.6",
         "@types/jsonwebtoken": "^9.0.9",
         "@types/node": "^20",
@@ -3520,16 +3518,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/@types/bcrypt": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
-      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/bcryptjs": {
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
@@ -4313,20 +4301,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
-    },
-    "node_modules/bcrypt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
-      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
     },
     "node_modules/bcryptjs": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "node --test tests",
     "postinstall": "prisma generate",
     "create-user": "tsx scripts/create-user.ts"
   },
@@ -40,7 +41,6 @@
     "@tanstack/react-table": "^8.16.0",
     "@uploadthing/react": "^6.4.4",
     "axios": "^1.6.8",
-    "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
@@ -63,7 +63,6 @@
     "zod": "^3.23.3"
   },
   "devDependencies": {
-    "@types/bcrypt": "^5.0.2",
     "@types/bcryptjs": "^2.4.6",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^20",

--- a/scripts/create-user.ts
+++ b/scripts/create-user.ts
@@ -1,5 +1,5 @@
 // scripts/create-user.ts
-import bcrypt from "bcrypt";
+import bcrypt from "bcryptjs";
 import inquirer from "inquirer";
 import { PrismaClient } from "@prisma/client";
 

--- a/tests/apiResponses.test.js
+++ b/tests/apiResponses.test.js
@@ -1,0 +1,9 @@
+import { error } from '../lib/apiResponses';
+import assert from 'assert';
+
+export async function test_error() {
+  const res = error('fail', 400);
+  assert.strictEqual(res.status, 400);
+  const data = await res.json();
+  assert.deepStrictEqual(data, { error: 'fail' });
+}

--- a/tests/spinner.test.js
+++ b/tests/spinner.test.js
@@ -1,0 +1,9 @@
+import assert from 'assert';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { Spinner } from '../components/ui/spinner';
+
+export function test_render() {
+  const html = renderToString(React.createElement(Spinner));
+  assert.ok(html.includes('div'));
+}


### PR DESCRIPTION
## Summary
- add generic API helpers and server action
- improve machine and master detail pages with loading spinners and typed state
- centralize add-product logic on server
- replace `bcrypt` with `bcryptjs`
- document env variables
- provide basic tests

## Testing
- `npm test` *(fails: Cannot find module '/workspace/venderp/lib/apiResponses' imported from /workspace/venderp/tests/apiResponses.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6852ed9241148332bdfd523097358191