### PR TITLE
Simplify POS forms

### DIFF
--- a/app/actions/createPos.ts
+++ b/app/actions/createPos.ts
@@ -2,22 +2,16 @@
 
 import { db } from "@/lib/db";
 import { revalidatePath } from "next/cache";
-import { randomUUID } from "crypto";
 import { generateCustomId } from "@/lib/customId";
 
 interface CreatePosInput {
   code: string;
   name: string;
   address: string;
-  city: string;
-  postalCode?: string;
-  province?: string;
-  country?: string;
-  contactName?: string;
-  contactPhone?: string;
-  contactEmail?: string;
   notes?: string;
   centerId: string;
+  machineId?: string;
+  masterId?: string;
 }
 
 export async function createPos(data: CreatePosInput) {
@@ -32,17 +26,12 @@ export async function createPos(data: CreatePosInput) {
       code: data.code,
       name: data.name,
       address: data.address,
-      city: data.city,
-      postalCode: data.postalCode,
-      province: data.province,
-      country: data.country || "España",
-      contactName: data.contactName,
-      contactPhone: data.contactPhone,
-      contactEmail: data.contactEmail,
       notes: data.notes,
       centerId: data.centerId,
       coverage: 0,
       customId: await generateCustomId("POS", center.tenantId),
+      ...(data.machineId ? { machine: { connect: { id: data.machineId } } } : {}),
+      ...(data.masterId ? { master: { connect: { id: data.masterId } } } : {}),
     },
   });
 

--- a/app/actions/updatePos.ts
+++ b/app/actions/updatePos.ts
@@ -6,16 +6,11 @@ import { z } from "zod";
 const schema = z.object({
   id: z.string(),
   name: z.string().min(2),
-  address: z.string().min(5),
-  city: z.string().min(2),
-  postalCode: z.string().optional(),
-  province: z.string().optional(),
-  country: z.string().optional(),
-  contactName: z.string().optional(),
-  contactPhone: z.string().optional(),
-  contactEmail: z.string().email().optional(),
+  address: z.string().min(2),
   notes: z.string().optional(),
   coverage: z.coerce.number().min(0).max(31).optional(),
+  machineId: z.string().optional(),
+  masterId: z.string().optional(),
 });
 
 export async function updatePos(input: z.infer<typeof schema>) {
@@ -26,15 +21,14 @@ export async function updatePos(input: z.infer<typeof schema>) {
     data: {
       name: values.name,
       address: values.address,
-      city: values.city,
-      postalCode: values.postalCode,
-      province: values.province,
-      country: values.country,
-      contactName: values.contactName,
-      contactPhone: values.contactPhone,
-      contactEmail: values.contactEmail,
       notes: values.notes,
       coverage: values.coverage ?? 0,
+      ...(values.machineId
+        ? { machine: { connect: { id: values.machineId } } }
+        : { machine: { disconnect: true } }),
+      ...(values.masterId
+        ? { master: { connect: { id: values.masterId } } }
+        : { master: { disconnect: true } }),
     },
   });
 }

--- a/app/api/machines/route.ts
+++ b/app/api/machines/route.ts
@@ -1,0 +1,17 @@
+import { db } from "@/lib/db";
+import { NextRequest, NextResponse } from "next/server";
+import { getServerAuthSession } from "@/lib/auth";
+
+export async function GET(req: NextRequest) {
+  const session = await getServerAuthSession();
+  const tenantId = session?.user?.tenant?.id;
+  if (!tenantId) return NextResponse.json([], { status: 401 });
+
+  const machines = await db.machine.findMany({
+    where: { center: { tenantId } },
+    include: { pos: true, center: true },
+    orderBy: { code: "asc" },
+  });
+
+  return NextResponse.json(machines);
+}

--- a/app/api/masters/auth/route.ts
+++ b/app/api/masters/auth/route.ts
@@ -1,0 +1,17 @@
+import { db } from "@/lib/db";
+import { NextResponse } from "next/server";
+import { getServerAuthSession } from "@/lib/auth";
+
+export async function GET() {
+  const session = await getServerAuthSession();
+  const tenantId = session?.user?.tenant?.id;
+  if (!tenantId) return NextResponse.json([], { status: 401 });
+
+  const masters = await db.master.findMany({
+    where: { tenantId },
+    include: { pos: true },
+    orderBy: { serialNumber: "asc" },
+  });
+
+  return NextResponse.json(masters);
+}

--- a/components/pos/detail/PosInfo.tsx
+++ b/components/pos/detail/PosInfo.tsx
@@ -25,17 +25,8 @@ export function PosInfo({ pos, onEdit }: Props) {
           <p>{pos.center.name}</p>
       </div>
       <div>
-        <p className="text-sm text-muted-foreground">Dirección</p>
-        <p>
-            {pos.address}, {pos.city}
-        </p>
-      </div>
-      <div>
-        <p className="text-sm text-muted-foreground">Contacto</p>
-        <p>
-            {pos.contactName || "-"}
-            {pos.contactPhone ? ` (${pos.contactPhone})` : ""}
-        </p>
+        <p className="text-sm text-muted-foreground">Ubicación</p>
+        <p>{pos.address}</p>
       </div>
       <div>
         <p className="text-sm text-muted-foreground">Master</p>

--- a/components/pos/forms/EditPosModal.tsx
+++ b/components/pos/forms/EditPosModal.tsx
@@ -8,7 +8,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { EditPosForm } from "./EditPosForm";
-import { POS, Center } from "@prisma/client";
+import { POS, Center, Machine, Master } from "@prisma/client";
 import { Button } from "@/components/ui/button";
 import { Pencil } from "lucide-react";
 import { useState } from "react";
@@ -17,6 +17,8 @@ import { useState } from "react";
 interface EditPosModalProps {
   pos: POS & {
     center: Center;
+    machine?: Machine | null;
+    master?: Master | null;
   };
   open?: boolean;
   onClose?: () => void;

--- a/components/pos/forms/NewPosForm.tsx
+++ b/components/pos/forms/NewPosForm.tsx
@@ -17,27 +17,24 @@ import {
   SelectItem,
 } from "@/components/ui/select";
 
-import { Center } from "@prisma/client";
+import { Center, Machine, Master } from "@prisma/client";
 import { createPos } from "@/app/actions/createPos"; // 🛠️ Asegúrate de tener este action
 
 const formSchema = z.object({
   code: z.string().min(2),
   name: z.string().min(2),
-  address: z.string().min(5),
-  city: z.string().min(2),
-  postalCode: z.string().optional(),
-  province: z.string().optional(),
-  country: z.string().optional(),
-  contactName: z.string().optional(),
-  contactPhone: z.string().optional(),
-  contactEmail: z.string().email().optional(),
+  address: z.string().min(2),
   notes: z.string().optional(),
   centerId: z.string().min(1, "Selecciona un centro"),
+  machineId: z.string().optional(),
+  masterId: z.string().optional(),
 });
 
 export function NewPosForm() {
   const router = useRouter();
   const [centers, setCenters] = useState<Center[]>([]);
+  const [machines, setMachines] = useState<Machine[]>([]);
+  const [masters, setMasters] = useState<Master[]>([]);
 
   const {
     register,
@@ -46,9 +43,7 @@ export function NewPosForm() {
     formState: { errors, isSubmitting },
   } = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: {
-      country: "España",
-    },
+    defaultValues: {},
   });
 
   useEffect(() => {
@@ -57,8 +52,21 @@ export function NewPosForm() {
       .then(setCenters);
   }, []);
 
-    const onSubmit = async (values: z.infer<typeof formSchema>) => {
-      await createPos(values);
+  useEffect(() => {
+    fetch("/api/machines")
+      .then((res) => res.json())
+      .then(setMachines);
+    fetch("/api/masters/auth")
+      .then((res) => res.json())
+      .then(setMasters);
+  }, []);
+
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    await createPos({
+      ...values,
+      machineId: values.machineId || undefined,
+      masterId: values.masterId || undefined,
+    });
     router.refresh();
   };
 
@@ -74,45 +82,8 @@ export function NewPosForm() {
       </div>
 
       <div>
-        <Label htmlFor="address">Dirección</Label>
+        <Label htmlFor="address">Ubicación</Label>
         <Input id="address" {...register("address")} />
-      </div>
-
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor="city">Ciudad</Label>
-          <Input id="city" {...register("city")} />
-        </div>
-        <div>
-          <Label htmlFor="postalCode">Código Postal</Label>
-          <Input id="postalCode" {...register("postalCode")} />
-        </div>
-      </div>
-
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor="province">Provincia</Label>
-          <Input id="province" {...register("province")} />
-        </div>
-        <div>
-          <Label htmlFor="country">País</Label>
-          <Input id="country" {...register("country")} />
-        </div>
-      </div>
-
-      <div>
-        <Label htmlFor="contactName">Nombre de contacto</Label>
-        <Input id="contactName" {...register("contactName")} />
-      </div>
-
-      <div>
-        <Label htmlFor="contactPhone">Teléfono</Label>
-        <Input id="contactPhone" {...register("contactPhone")} />
-      </div>
-
-      <div>
-        <Label htmlFor="contactEmail">Email</Label>
-        <Input id="contactEmail" {...register("contactEmail")} />
       </div>
 
       <div>
@@ -132,6 +103,38 @@ export function NewPosForm() {
         {errors.centerId && (
           <p className="text-xs text-red-500 mt-1">{errors.centerId.message}</p>
         )}
+      </div>
+
+      <div>
+        <Label>Máquina</Label>
+        <Select onValueChange={(v) => setValue("machineId", v)}>
+          <SelectTrigger>
+            <SelectValue placeholder="Selecciona máquina" />
+          </SelectTrigger>
+          <SelectContent>
+            {machines.map((m) => (
+              <SelectItem key={m.id} value={m.id}>
+                {m.code}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div>
+        <Label>Master</Label>
+        <Select onValueChange={(v) => setValue("masterId", v)}>
+          <SelectTrigger>
+            <SelectValue placeholder="Selecciona master" />
+          </SelectTrigger>
+          <SelectContent>
+            {masters.map((m) => (
+              <SelectItem key={m.id} value={m.id}>
+                {m.serialNumber}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       <div>


### PR DESCRIPTION
## Summary
- add routes to fetch machines and masters
- streamline create/updatePos actions
- remove unused POS fields and add selectors for machine and master
- update edit modal and info display

## Testing
- `npm test` *(fails: Cannot find module '/workspace/venderp/tests')*

------
https://chatgpt.com/codex/tasks/task_e_6857bd8ffbd083329b7175c1cc9c9f7f