### PR TITLE
Update machine schema and forms

### DIFF
--- a/app/(routes)/maintenance/page.tsx
+++ b/app/(routes)/maintenance/page.tsx
@@ -31,7 +31,7 @@ export default async function MaintenancePage() {
               >
                 <div className="flex justify-between items-center">
                   <p className="font-semibold">
-                    {log.machine.code} – {log.machine.model}
+                    {log.machine.customId ?? log.machine.id} – {log.machine.model}
                   </p>
                   <Badge
                     variant={

--- a/app/actions/createMachine.ts
+++ b/app/actions/createMachine.ts
@@ -5,37 +5,34 @@ import { db } from "@/lib/db";
 import { generateCustomId } from "@/lib/customId";
 import { z } from "zod";
 import { MachineStatus, MachineType } from "@prisma/client";
+import { getServerAuthSession } from "@/lib/auth";
 
 const schema = z.object({
-  code: z.string().min(2),
   model: z.string().optional(),
   serialNumber: z.string().optional(),
   type: z.nativeEnum(MachineType),
   status: z.nativeEnum(MachineStatus),
-  posId: z.string(),
-  centerId: z.string(),
+  posId: z.string().optional(),
+  centerId: z.string().optional(),
   installedAt: z.string().optional(), // viene como string del input type="date"
 });
 
 export async function createMachine(input: z.infer<typeof schema>) {
   const data = schema.parse(input);
-  const center = await db.center.findUnique({
-    where: { id: data.centerId },
-    select: { tenantId: true },
-  });
-  if (!center) throw new Error("Center not found");
+  const session = await getServerAuthSession();
+  const tenantId = session?.user?.tenant?.id;
+  if (!tenantId) throw new Error("Tenant not found");
 
-  const customId = await generateCustomId("Machine", center.tenantId);
+  const customId = await generateCustomId("Machine", tenantId);
 
   await db.machine.create({
     data: {
-      code: data.code,
       model: data.model || null,
       serialNumber: data.serialNumber || null,
       type: data.type,
       status: data.status,
-      posId: data.posId,
-      centerId: data.centerId,
+      posId: data.posId ?? null,
+      centerId: data.centerId ?? null,
       installedAt: data.installedAt ? new Date(data.installedAt) : null,
       customId,
     },

--- a/app/actions/updateMachine.ts
+++ b/app/actions/updateMachine.ts
@@ -7,12 +7,11 @@ import { MachineStatus, MachineType } from "@prisma/client";
 
 const schema = z.object({
   id: z.string(),
-  code: z.string().min(2),
   model: z.string().optional(),
   serialNumber: z.string().optional(),
   type: z.nativeEnum(MachineType),
   status: z.nativeEnum(MachineStatus),
-  posId: z.string(),
+  posId: z.string().optional(),
   installedAt: z.string().optional(), // viene como string del input
 });
 
@@ -22,12 +21,11 @@ export async function updateMachine(input: z.infer<typeof schema>) {
   await db.machine.update({
     where: { id: data.id },
     data: {
-      code: data.code,
       model: data.model || null,
       serialNumber: data.serialNumber || null,
       type: data.type,
       status: data.status,
-      posId: data.posId,
+      posId: data.posId ?? null,
       installedAt: data.installedAt ? new Date(data.installedAt) : null,
     },
   });

--- a/app/api/machines/[id]/sales/route.ts
+++ b/app/api/machines/[id]/sales/route.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { SaleMethod } from "@prisma/client";
 
 const saleSchema = z.object({
-  machineCode: z.string(),
+  machineCustomId: z.coerce.number(),
   line: z.string(),
   method: z.nativeEnum(SaleMethod),
   price: z.number(),
@@ -17,8 +17,8 @@ export async function POST(req: NextRequest) {
   try {
     const data = saleSchema.parse(await req.json());
 
-    const machine = await db.machine.findUnique({
-      where: { code: data.machineCode },
+    const machine = await db.machine.findFirst({
+      where: { customId: data.machineCustomId },
     });
 
     if (!machine) {
@@ -72,7 +72,7 @@ export async function GET(req: NextRequest) {
   const posId = req.nextUrl.searchParams.get("posId");
   let where;
   if (machine) {
-    const m = await db.machine.findUnique({ where: { code: machine } });
+    const m = await db.machine.findFirst({ where: { customId: Number(machine) } });
     if (!m || !m.posId) {
       return NextResponse.json({ error: "Machine not found" }, { status: 404 });
     }

--- a/app/api/machines/route.ts
+++ b/app/api/machines/route.ts
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest) {
   const machines = await db.machine.findMany({
     where: { center: { tenantId } },
     include: { pos: true, center: true },
-    orderBy: { code: "asc" },
+    orderBy: { customId: "asc" },
   });
 
   return NextResponse.json(machines);

--- a/components/machines/MachineTable.tsx
+++ b/components/machines/MachineTable.tsx
@@ -13,8 +13,8 @@ export function MachineTable({ data }: MachineTableProps) {
     <DataTable
       columns={columns}
       data={data}
-      filterColumn="code"
-      searchPlaceholder="Buscar por código..."
+      filterColumn="customId"
+      searchPlaceholder="Buscar por ID..."
     />
   );
 }

--- a/components/machines/columns.tsx
+++ b/components/machines/columns.tsx
@@ -11,13 +11,14 @@ import { EditMachineModal } from "./forms/EditMachineModal";
 export const columns: ColumnDef<Machine & { pos: { name: string } | null }>[] =
   [
     {
-      accessorKey: "code", // Columna de código
+      accessorKey: "customId",
       header: "Máquina",
       cell: ({ row }) => {
         const machine = row.original;
+        const id = row.getValue("customId") || machine.id;
         return (
           <div className="flex items-center gap-2 justify-between">
-            <span className="font-medium">{row.getValue("code")}</span>
+            <span className="font-medium">{id}</span>
             <Link href={`/machines/${machine.id}`}>
               <Button variant="ghost" size="icon">
                 <Eye className="w-4 h-4" />
@@ -61,13 +62,17 @@ export const columns: ColumnDef<Machine & { pos: { name: string } | null }>[] =
             ? "default"
             : status === "OUT_OF_SERVICE"
             ? "destructive"
-            : "secondary";
+            : status === "RETIRED"
+            ? "secondary"
+            : "outline";
         const label =
           status === "ACTIVE"
             ? "Activa"
             : status === "OUT_OF_SERVICE"
             ? "Fuera de servicio"
-            : "Retirada";
+            : status === "RETIRED"
+            ? "Retirada"
+            : "Sin instalar";
         return <Badge variant={variant}>{label}</Badge>;
       },
     },

--- a/components/machines/detail/MachineInfo.tsx
+++ b/components/machines/detail/MachineInfo.tsx
@@ -24,8 +24,8 @@ export function MachineInfo({ machine, onEdit }: Props) {
         </Button>
       </div>
       <div>
-        <p className="text-sm text-muted-foreground">Código</p>
-        <p className="font-medium">{machine.code}</p>
+        <p className="text-sm text-muted-foreground">ID</p>
+        <p className="font-medium">{machine.customId ?? machine.id}</p>
       </div>
 
       <div>
@@ -94,6 +94,8 @@ function getStatusLabel(status: MachineStatus) {
       return "Fuera de servicio";
     case "RETIRED":
       return "Retirada";
+    case "NOT_INSTALLED":
+      return "Sin instalar";
     default:
       return status;
   }
@@ -107,6 +109,8 @@ function getStatusVariant(status: MachineStatus) {
       return "destructive";
     case "RETIRED":
       return "secondary";
+    case "NOT_INSTALLED":
+      return "outline";
     default:
       return "outline";
   }

--- a/components/machines/detail/stock/AddProductModal.tsx
+++ b/components/machines/detail/stock/AddProductModal.tsx
@@ -87,7 +87,9 @@ export function AddProductModal({
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="max-w-xl">
         <DialogHeader>
-          <DialogTitle>Añadir producto a la máquina {machine.code}</DialogTitle>
+          <DialogTitle>
+            Añadir producto a la máquina {machine.customId ?? machine.id}
+          </DialogTitle>
         </DialogHeader>
 
         {/* Selección de producto */}

--- a/components/machines/forms/EditMachineModal.tsx
+++ b/components/machines/forms/EditMachineModal.tsx
@@ -25,12 +25,11 @@ import { useEffect, useState } from "react";
 
 const formSchema = z.object({
   id: z.string(),
-  code: z.string().min(2),
   model: z.string().optional(),
   serialNumber: z.string().optional(),
   type: z.nativeEnum(MachineType),
   status: z.nativeEnum(MachineStatus),
-  posId: z.string(),
+  posId: z.string().optional(),
   installedAt: z.string().optional(),
 });
 
@@ -53,7 +52,6 @@ export function EditMachineModal({ machine, open, onClose, onSuccess }: Props) {
     resolver: zodResolver(formSchema),
     defaultValues: {
       id: machine.id,
-      code: machine.code,
       model: machine.model ?? "",
       serialNumber: machine.serialNumber ?? "",
       type: machine.type,
@@ -93,13 +91,6 @@ export function EditMachineModal({ machine, open, onClose, onSuccess }: Props) {
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <input type="hidden" {...register("id")} />
 
-          <div>
-            <Label htmlFor="code">Código</Label>
-            <Input id="code" {...register("code")} />
-            {errors.code && (
-              <p className="text-xs text-red-500">{errors.code.message}</p>
-            )}
-          </div>
 
           <div>
             <Label htmlFor="model">Modelo</Label>
@@ -144,6 +135,7 @@ export function EditMachineModal({ machine, open, onClose, onSuccess }: Props) {
                   Fuera de servicio
                 </SelectItem>
                 <SelectItem value="RETIRED">Retirada</SelectItem>
+                <SelectItem value="NOT_INSTALLED">Sin instalar</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/components/machines/forms/NewMachineForm.tsx
+++ b/components/machines/forms/NewMachineForm.tsx
@@ -31,15 +31,13 @@ type CenterBasic = {
 };
 
 const formSchema = z.object({
-  code: z.string().min(2),
   model: z.string().optional(),
   serialNumber: z.string().optional(),
   type: z.nativeEnum(MachineType),
   status: z.nativeEnum(MachineStatus),
-  centerId: z.string(),
-  posId: z.string(),
+  centerId: z.string().optional(),
+  posId: z.string().optional(),
   installedAt: z.string().optional(),
-  customId: z.coerce.number().optional(),
 });
 
 export function NewMachineForm() {
@@ -87,18 +85,6 @@ export function NewMachineForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-      <div>
-        <Label htmlFor="code">Código</Label>
-        <Input id="code" {...register("code")} />
-        {errors.code && (
-          <p className="text-xs text-red-500">{errors.code.message}</p>
-        )}
-      </div>
-
-      <div>
-        <Label htmlFor="customId">ID</Label>
-        <Input id="customId" type="number" {...register("customId")} />
-      </div>
 
       <div>
         <Label htmlFor="model">Modelo</Label>
@@ -141,6 +127,7 @@ export function NewMachineForm() {
             <SelectItem value="ACTIVE">Activa</SelectItem>
             <SelectItem value="OUT_OF_SERVICE">Fuera de servicio</SelectItem>
             <SelectItem value="RETIRED">Retirada</SelectItem>
+            <SelectItem value="NOT_INSTALLED">Sin instalar</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/prisma/migrations/20250618101010_machine_update/migration.sql
+++ b/prisma/migrations/20250618101010_machine_update/migration.sql
@@ -1,0 +1,10 @@
+-- AlterEnum
+ALTER TYPE "MachineStatus" ADD VALUE IF NOT EXISTS 'NOT_INSTALLED';
+
+-- DropIndex
+DROP INDEX IF EXISTS "Machine_code_key";
+
+-- AlterTable
+ALTER TABLE "Machine"
+  DROP COLUMN IF EXISTS "code",
+  ALTER COLUMN "centerId" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -147,15 +147,14 @@ model Master {
 model Machine {
   id           String        @id @default(uuid())
   customId     Int?          @unique
-  code         String        @unique
   model        String?
   serialNumber String?       @unique
   type         MachineType
   status       MachineStatus @default(ACTIVE)
   lastCheck    DateTime?
   installedAt  DateTime?
-  centerId     String
-  center       Center        @relation(fields: [centerId], references: [id])
+  centerId     String?
+  center       Center?       @relation(fields: [centerId], references: [id])
 
   posId String? @unique
   pos   POS?    @relation(fields: [posId], references: [id])
@@ -181,6 +180,7 @@ enum MachineStatus {
   ACTIVE
   OUT_OF_SERVICE
   RETIRED
+  NOT_INSTALLED
 }
 
 model Product {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -98,7 +98,6 @@ async function main() {
 
           const machine = await prisma.machine.create({
             data: {
-              code: faker.string.uuid(),
               model: "Basic Vender",
               serialNumber: faker.string.alphanumeric(10),
               type: "SNACK",


### PR DESCRIPTION
## Summary
- drop `code` from `Machine` model and make `centerId` optional
- add new enum value `NOT_INSTALLED`
- migrate DB to drop code column
- update machine create and update actions
- use `customId` across machine UI and API
- adjust maintenance list and sales endpoints

## Testing
- `npm test` *(fails: Cannot find module '/workspace/venderp/tests')*

------
https://chatgpt.com/codex/tasks/task_e_6857ee09da6c8332b5a8cc81cdb610e9