### PR TITLE
Adjust machine tenant relation

### DIFF
--- a/app/(routes)/dashboard/page.tsx
+++ b/app/(routes)/dashboard/page.tsx
@@ -14,8 +14,8 @@ export default async function DashboardPage() {
   const tenantId = session?.user?.tenant?.id;
 
   const [activeMachines, totalMachines, sales] = await Promise.all([
-    db.machine.count({ where: { status: "ACTIVE", center: { tenantId } } }),
-    db.machine.count({ where: { center: { tenantId } } }),
+    db.machine.count({ where: { status: "ACTIVE", tenantId } }),
+    db.machine.count({ where: { tenantId } }),
     db.sale.aggregate({
       _sum: { price: true },
       where: {

--- a/app/(routes)/machines/page.tsx
+++ b/app/(routes)/machines/page.tsx
@@ -8,7 +8,7 @@ export default async function MachinesPage() {
   const tenantId = session?.user?.tenant?.id;
 
   const machines = await db.machine.findMany({
-    where: { center: { tenantId } },
+    where: { tenantId },
     include: {
       pos: {
         select: {

--- a/app/actions/createMachine.ts
+++ b/app/actions/createMachine.ts
@@ -12,8 +12,6 @@ const schema = z.object({
   serialNumber: z.string().optional(),
   type: z.nativeEnum(MachineType),
   status: z.nativeEnum(MachineStatus),
-  posId: z.string().optional(),
-  centerId: z.string().optional(),
   installedAt: z.string().optional(), // viene como string del input type="date"
 });
 
@@ -31,8 +29,7 @@ export async function createMachine(input: z.infer<typeof schema>) {
       serialNumber: data.serialNumber || null,
       type: data.type,
       status: data.status,
-      posId: data.posId ?? null,
-      centerId: data.centerId ?? null,
+      tenantId,
       installedAt: data.installedAt ? new Date(data.installedAt) : null,
       customId,
     },

--- a/app/api/machines/[id]/route.ts
+++ b/app/api/machines/[id]/route.ts
@@ -11,10 +11,9 @@ export async function GET(
     const tenantId = session?.user?.tenant?.id;
 
     const machine = await db.machine.findFirst({
-      where: { id: params.id, center: { tenantId } },
+      where: { id: params.id, tenantId },
       include: {
         pos: true,
-        center: true,
         products: {
           include: {
             product: true,

--- a/app/api/machines/route.ts
+++ b/app/api/machines/route.ts
@@ -8,8 +8,8 @@ export async function GET(req: NextRequest) {
   if (!tenantId) return NextResponse.json([], { status: 401 });
 
   const machines = await db.machine.findMany({
-    where: { center: { tenantId } },
-    include: { pos: true, center: true },
+    where: { tenantId },
+    include: { pos: true },
     orderBy: { customId: "asc" },
   });
 

--- a/app/api/metrics/summary/route.ts
+++ b/app/api/metrics/summary/route.ts
@@ -8,8 +8,8 @@ export async function GET() {
     const tenantId = session?.user?.tenant?.id;
 
     const [activeMachines, totalMachines, sales] = await Promise.all([
-      db.machine.count({ where: { status: "ACTIVE", center: { tenantId } } }),
-      db.machine.count({ where: { center: { tenantId } } }),
+      db.machine.count({ where: { status: "ACTIVE", tenantId } }),
+      db.machine.count({ where: { tenantId } }),
       db.sale.aggregate({
         _sum: { price: true },
         where: {

--- a/components/dashboard/MachineConnections/MachineConnections.tsx
+++ b/components/dashboard/MachineConnections/MachineConnections.tsx
@@ -10,7 +10,7 @@ export async function MachineConnections() {
     const tenantId = session?.user?.tenant?.id
 
     const machines = await db.machine.findMany({
-        where: { center: { tenantId } },
+        where: { tenantId },
         include: { pos: { select: { name: true } } },
         orderBy: { createdAt: "desc" },
         take: 5,

--- a/components/machines/forms/EditMachineModal.tsx
+++ b/components/machines/forms/EditMachineModal.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Center, Machine, MachineStatus, MachineType } from "@prisma/client";
+import { POS, Machine, MachineStatus, MachineType } from "@prisma/client";
 import { updateMachine } from "@/app/actions/updateMachine";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -41,7 +41,7 @@ interface Props {
 }
 
 export function EditMachineModal({ machine, open, onClose, onSuccess }: Props) {
-  const [centers, setCenters] = useState<Center[]>([]);
+  const [posList, setPosList] = useState<POS[]>([]);
 
   const {
     register,
@@ -64,9 +64,9 @@ export function EditMachineModal({ machine, open, onClose, onSuccess }: Props) {
   });
 
   useEffect(() => {
-    fetch("/api/centers")
+    fetch("/api/pos")
       .then((res) => res.json())
-      .then(setCenters);
+      .then(setPosList);
   }, []);
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
@@ -141,7 +141,7 @@ export function EditMachineModal({ machine, open, onClose, onSuccess }: Props) {
           </div>
 
           <div>
-          <Label htmlFor="posId">PDV / Centro</Label>
+          <Label htmlFor="posId">PDV</Label>
           <Select
               defaultValue={machine.posId ?? undefined}
               onValueChange={(v) => setValue("posId", v)}
@@ -150,9 +150,9 @@ export function EditMachineModal({ machine, open, onClose, onSuccess }: Props) {
                 <SelectValue placeholder="Selecciona PDV" />
               </SelectTrigger>
               <SelectContent>
-                {centers.map((center) => (
-                  <SelectItem key={center.id} value={center.id}>
-                    {center.name}
+                {posList.map((pos) => (
+                  <SelectItem key={pos.id} value={pos.id}>
+                    {pos.name}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/components/machines/forms/NewMachineForm.tsx
+++ b/components/machines/forms/NewMachineForm.tsx
@@ -5,7 +5,6 @@ import { z } from "zod";
 import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { MachineType, MachineStatus } from "@prisma/client";
-import { useEffect, useState } from "react";
 
 import { createMachine } from "@/app/actions/createMachine";
 import { Input } from "@/components/ui/input";
@@ -20,38 +19,22 @@ import {
 } from "@/components/ui/select";
 import { toast } from "@/components/ui/use-toast";
 
-type PosWithCenter = {
-  id: string;
-  name: string;
-  centerId: string;
-};
-
-type CenterBasic = {
-  id: string;
-  name: string;
-};
 
 const formSchema = z.object({
   model: z.string().optional(),
   serialNumber: z.string().optional(),
   type: z.nativeEnum(MachineType),
   status: z.nativeEnum(MachineStatus),
-  centerId: z.string().optional(),
-  posId: z.string().optional(),
   installedAt: z.string().optional(),
 });
 
 export function NewMachineForm({ onSuccess }: { onSuccess?: () => void }) {
   const router = useRouter();
-  const [centers, setCenters] = useState<CenterBasic[]>([]);
-  const [posList, setPosList] = useState<PosWithCenter[]>([]);
-  const [selectedCenterId, setSelectedCenterId] = useState<string | null>(null);
 
   const {
     register,
     handleSubmit,
     setValue,
-    watch,
     formState: { errors, isSubmitting },
   } = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -61,23 +44,6 @@ export function NewMachineForm({ onSuccess }: { onSuccess?: () => void }) {
     },
   });
 
-  // Cargar centros
-  useEffect(() => {
-    fetch("/api/centers")
-      .then((res) => res.json())
-      .then(setCenters);
-  }, []);
-
-  // Cargar POS
-  useEffect(() => {
-    fetch("/api/pos")
-      .then((res) => res.json())
-      .then(setPosList);
-  }, []);
-
-  const filteredPos = posList.filter(
-    (loc) => loc.centerId === selectedCenterId
-  );
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
@@ -142,51 +108,6 @@ export function NewMachineForm({ onSuccess }: { onSuccess?: () => void }) {
         </Select>
       </div>
 
-      <div>
-        <Label>Centro</Label>
-        <Select
-          onValueChange={(v) => {
-            setValue("centerId", v);
-            setSelectedCenterId(v);
-            setValue("posId", ""); // Reset POS
-          }}
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Selecciona centro (opcional)" />
-          </SelectTrigger>
-          <SelectContent>
-            {centers.map((center) => (
-              <SelectItem key={center.id} value={center.id}>
-                {center.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {errors.centerId && (
-          <p className="text-xs text-red-500">{errors.centerId.message}</p>
-        )}
-      </div>
-
-      {selectedCenterId && (
-        <div>
-          <Label>PDV</Label>
-          <Select onValueChange={(v) => setValue("posId", v)}>
-          <SelectTrigger>
-            <SelectValue placeholder="Selecciona PDV (opcional)" />
-          </SelectTrigger>
-            <SelectContent>
-              {filteredPos.map((pos) => (
-                <SelectItem key={pos.id} value={pos.id}>
-                  {pos.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {errors.posId && (
-            <p className="text-xs text-red-500">{errors.posId.message}</p>
-          )}
-        </div>
-      )}
 
       <div>
         <Label htmlFor="installedAt">Fecha de instalación</Label>

--- a/prisma/migrations/20250622151300_machine_tenant/migration.sql
+++ b/prisma/migrations/20250622151300_machine_tenant/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "Machine" ADD COLUMN "tenantId" TEXT;
+
+UPDATE "Machine" SET "tenantId" = c."tenantId"
+FROM "Center" c
+WHERE "Machine"."centerId" = c.id;
+
+ALTER TABLE "Machine" ALTER COLUMN "tenantId" SET NOT NULL;
+
+ALTER TABLE "Machine" DROP CONSTRAINT IF EXISTS "Machine_centerId_fkey";
+ALTER TABLE "Machine" DROP COLUMN "centerId";
+
+-- AddForeignKey
+ALTER TABLE "Machine" ADD CONSTRAINT "Machine_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,8 +153,8 @@ model Machine {
   status       MachineStatus @default(ACTIVE)
   lastCheck    DateTime?
   installedAt  DateTime?
-  centerId     String?
-  center       Center?       @relation(fields: [centerId], references: [id])
+  tenantId     String
+  tenant       Tenant        @relation(fields: [tenantId], references: [id])
 
   posId String? @unique
   pos   POS?    @relation(fields: [posId], references: [id])

--- a/types/machine.type.ts
+++ b/types/machine.type.ts
@@ -2,13 +2,11 @@ import {
   Machine,
   MachineProduct,
   Product,
-  Center,
   POS,
 } from "@prisma/client";
 
 export type MachineWithDetails = Machine & {
-  center: Center;
-  pos: POS;
+  pos: POS | null;
   products: (MachineProduct & {
     product: Product;
   })[];


### PR DESCRIPTION
## Summary
- link machines directly with tenants in Prisma schema
- drop center references on machine creation
- load POS list when editing machines
- simplify new machine form
- query machines by tenant id
- update dashboard and metrics to use new relation
- add migration for new machine tenant relation

## Testing
- `npm test` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68581818ed0c8332aac233153cdaaeb9