### PR TITLE
Add brand field to Machine model

### DIFF
--- a/app/actions/createMachine.ts
+++ b/app/actions/createMachine.ts
@@ -8,6 +8,7 @@ import { MachineStatus, MachineType } from "@prisma/client";
 import { getServerAuthSession } from "@/lib/auth";
 
 const schema = z.object({
+  brand: z.string().optional(),
   model: z.string().optional(),
   serialNumber: z.string().optional(),
   type: z.nativeEnum(MachineType),
@@ -25,6 +26,7 @@ export async function createMachine(input: z.infer<typeof schema>) {
 
   await db.machine.create({
     data: {
+      brand: data.brand || null,
       model: data.model || null,
       serialNumber: data.serialNumber || null,
       type: data.type,

--- a/app/actions/updateMachine.ts
+++ b/app/actions/updateMachine.ts
@@ -7,6 +7,7 @@ import { MachineStatus, MachineType } from "@prisma/client";
 
 const schema = z.object({
   id: z.string(),
+  brand: z.string().optional(),
   model: z.string().optional(),
   serialNumber: z.string().optional(),
   type: z.nativeEnum(MachineType),
@@ -21,6 +22,7 @@ export async function updateMachine(input: z.infer<typeof schema>) {
   await db.machine.update({
     where: { id: data.id },
     data: {
+      brand: data.brand || null,
       model: data.model || null,
       serialNumber: data.serialNumber || null,
       type: data.type,

--- a/components/machines/columns.tsx
+++ b/components/machines/columns.tsx
@@ -30,6 +30,14 @@ export const columns: ColumnDef<Machine & { pos: { name: string } | null }>[] =
       },
     },
     {
+      accessorKey: "brand",
+      header: "Marca",
+      cell: ({ row }) =>
+        row.getValue("brand") || (
+          <span className="text-muted-foreground italic">–</span>
+        ),
+    },
+    {
       accessorKey: "model",
       header: "Modelo",
       cell: ({ row }) =>

--- a/components/machines/detail/MachineInfo.tsx
+++ b/components/machines/detail/MachineInfo.tsx
@@ -80,6 +80,15 @@ export function MachineInfo({ machine, onEdit }: Props) {
       </div>
 
       <div>
+        <p className="text-sm text-muted-foreground">Marca</p>
+        <p>
+          {machine.brand || (
+            <span className="italic text-muted-foreground">No especificada</span>
+          )}
+        </p>
+      </div>
+
+      <div>
         <p className="text-sm text-muted-foreground">Modelo</p>
         <p>
           {machine.model || (

--- a/components/machines/forms/EditMachineModal.tsx
+++ b/components/machines/forms/EditMachineModal.tsx
@@ -25,6 +25,7 @@ import { useEffect, useState } from "react";
 
 const formSchema = z.object({
   id: z.string(),
+  brand: z.string().optional(),
   model: z.string().optional(),
   serialNumber: z.string().optional(),
   type: z.nativeEnum(MachineType),
@@ -52,6 +53,7 @@ export function EditMachineModal({ machine, open, onClose, onSuccess }: Props) {
     resolver: zodResolver(formSchema),
     defaultValues: {
       id: machine.id,
+      brand: machine.brand ?? "",
       model: machine.model ?? "",
       serialNumber: machine.serialNumber ?? "",
       type: machine.type,
@@ -91,6 +93,10 @@ export function EditMachineModal({ machine, open, onClose, onSuccess }: Props) {
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <input type="hidden" {...register("id")} />
 
+          <div>
+            <Label htmlFor="brand">Marca</Label>
+            <Input id="brand" {...register("brand")} />
+          </div>
 
           <div>
             <Label htmlFor="model">Modelo</Label>

--- a/components/machines/forms/NewMachineForm.tsx
+++ b/components/machines/forms/NewMachineForm.tsx
@@ -21,6 +21,7 @@ import { toast } from "@/components/ui/use-toast";
 
 
 const formSchema = z.object({
+  brand: z.string().optional(),
   model: z.string().optional(),
   serialNumber: z.string().optional(),
   type: z.nativeEnum(MachineType),
@@ -62,6 +63,10 @@ export function NewMachineForm({ onSuccess }: { onSuccess?: () => void }) {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div>
+        <Label htmlFor="brand">Marca</Label>
+        <Input id="brand" {...register("brand")} />
+      </div>
       <div>
         <Label htmlFor="model">Modelo</Label>
         <Input id="model" {...register("model")} />

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,6 +148,7 @@ model Master {
 model Machine {
   id           String        @id @default(uuid())
   customId     Int?          @unique
+  brand        String?
   model        String?
   serialNumber String?       @unique
   type         MachineType

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -98,6 +98,7 @@ async function main() {
 
           const machine = await prisma.machine.create({
             data: {
+              brand: faker.company.name(),
               model: "Basic Vender",
               serialNumber: faker.string.alphanumeric(10),
               type: "SNACK",


### PR DESCRIPTION
## Summary
- extend `Machine` model with `brand`
- support brand in machine creation/update actions
- include brand field in machine forms and UI
- seed machines with a fake brand

## Testing
- `npm test` *(fails: Cannot find module '/workspace/venderp/tests')*
- `node --test tests/apiResponses.test.js tests/spinner.test.js` *(fails: ERR_MODULE_NOT_FOUND)*
- `npx prisma format` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6859c000987083328b1a253e5f1203d1