### PR TITLE
Add machine channel configuration UI

### DIFF
--- a/components/machines/detail/stock/ChannelConfigurator.tsx
+++ b/components/machines/detail/stock/ChannelConfigurator.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { MachineProduct, Product } from "@prisma/client";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { MachineWithProducts } from "../MachineDetailsTabs";
+
+interface Props {
+  machine: MachineWithProducts;
+}
+
+export function ChannelConfigurator({ machine }: Props) {
+  const [rows, setRows] = useState<number>(3);
+  const [cols, setCols] = useState<number>(3);
+
+  // Crear matriz vacía
+  const grid: (MachineProduct & { product: Product })[][] = Array.from(
+    { length: rows },
+    () => Array(cols).fill(null)
+  );
+
+  // Colocar productos en la matriz según línea y selección
+  machine.products.forEach((mp) => {
+    const r = parseInt(mp.line) - 1;
+    const c = parseInt(mp.selection) - 1;
+    if (!isNaN(r) && !isNaN(c) && r >= 0 && c >= 0 && r < rows && c < cols) {
+      grid[r][c] = mp as any;
+    }
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-4">
+        <div>
+          <Label htmlFor="rows">Filas</Label>
+          <Input
+            id="rows"
+            type="number"
+            min={1}
+            value={rows}
+            onChange={(e) => setRows(Number(e.target.value))}
+            className="w-20"
+          />
+        </div>
+        <div>
+          <Label htmlFor="cols">Columnas</Label>
+          <Input
+            id="cols"
+            type="number"
+            min={1}
+            value={cols}
+            onChange={(e) => setCols(Number(e.target.value))}
+            className="w-20"
+          />
+        </div>
+      </div>
+      <div className="overflow-auto">
+        <div
+          className="grid gap-2"
+          style={{ gridTemplateColumns: `repeat(${cols}, minmax(120px,1fr))` }}
+        >
+          {grid.map((row, rIdx) =>
+            row.map((cell, cIdx) => (
+              <div
+                key={`${rIdx}-${cIdx}`}
+                className="border rounded p-2 text-xs space-y-1"
+              >
+                {cell ? (
+                  <>
+                    <div className="font-medium text-sm">
+                      {cell.product.name}
+                    </div>
+                    <div className="flex justify-between text-muted-foreground">
+                      <span>L{cell.line}</span>
+                      <span>S{cell.selection}</span>
+                    </div>
+                    <div className="text-right font-semibold">
+                      {cell.price.toFixed(2)}€
+                    </div>
+                  </>
+                ) : (
+                  <div className="text-muted-foreground text-center py-6">
+                    Vacío
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/machines/detail/stock/ChannelConfiguratorModal.tsx
+++ b/components/machines/detail/stock/ChannelConfiguratorModal.tsx
@@ -1,0 +1,22 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { MachineWithProducts } from "../MachineDetailsTabs";
+import { ChannelConfigurator } from "./ChannelConfigurator";
+
+interface Props {
+  machine: MachineWithProducts;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ChannelConfiguratorModal({ machine, open, onClose }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Configurar canales</DialogTitle>
+        </DialogHeader>
+        <ChannelConfigurator machine={machine} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/machines/detail/stock/MachineStockTable.tsx
+++ b/components/machines/detail/stock/MachineStockTable.tsx
@@ -14,6 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { AddProductModal } from "@/components/machines/detail/stock/AddProductModal";
 import { AdjustStockModal } from "@/components/machines/detail/stock/AdjustStockModal";
+import { ChannelConfiguratorModal } from "@/components/machines/detail/stock/ChannelConfiguratorModal";
 
 interface Props {
   machine: MachineWithProducts;
@@ -28,6 +29,7 @@ export function MachineStockTable({ machine }: Props) {
     null
   );
   const [selectedProductName, setSelectedProductName] = useState<string>("");
+  const [configOpen, setConfigOpen] = useState(false);
 
   useEffect(() => {
     setProducts(machine.products);
@@ -86,6 +88,9 @@ export function MachineStockTable({ machine }: Props) {
           onClick={() => setDeleteMode(!deleteMode)}
         >
           {deleteMode ? "Cancelar eliminar" : "Eliminar producto"}
+        </Button>
+        <Button variant="secondary" onClick={() => setConfigOpen(true)}>
+          Configurar canales
         </Button>
       </div>
 
@@ -176,6 +181,14 @@ export function MachineStockTable({ machine }: Props) {
             closeAddProductModal();
             refreshProducts(); // <-- Refetch automático aquí
           }}
+        />
+      )}
+
+      {configOpen && (
+        <ChannelConfiguratorModal
+          machine={{ ...machine, products }}
+          open={configOpen}
+          onClose={() => setConfigOpen(false)}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- add `ChannelConfigurator` component to allow configuring vending machine channels
- add `ChannelConfiguratorModal`
- integrate channel configuration modal into `MachineStockTable`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/venderp/tests')*
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: many module not found errors)*

------
https://chatgpt.com/codex/tasks/task_e_685abda3b8588332a1cdc52a082453ef