### PR TITLE
Add channel configuration page with product grid

### DIFF
--- a/app/(routes)/machines/[id]/channels/page.tsx
+++ b/app/(routes)/machines/[id]/channels/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { ChannelConfigurator } from "@/components/machines/detail/stock/ChannelConfigurator";
+import { Spinner } from "@/components/ui/spinner";
+import { Button } from "@/components/ui/button";
+import { MachineWithDetails } from "@/types";
+
+async function fetchMachineData(id: string) {
+  const res = await fetch(`/api/machines/${id}`);
+  if (!res.ok) {
+    throw new Error("Error fetching machine data");
+  }
+  return res.json();
+}
+
+export default function ChannelConfigPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const [machine, setMachine] = useState<MachineWithDetails | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchMachineData(params.id)
+      .then(setMachine)
+      .catch((err) => console.error(err))
+      .finally(() => setLoading(false));
+  }, [params.id]);
+
+  return (
+    <div className="p-6 space-y-8">
+      <div className="flex items-center gap-2">
+        <Button asChild variant="default" size="icon">
+          <Link href={`/machines/${params.id}`}>
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <h2 className="text-2xl font-bold">Configurar canales</h2>
+      </div>
+      {loading && (
+        <div className="flex justify-center py-10">
+          <Spinner />
+        </div>
+      )}
+      {!loading && machine && <ChannelConfigurator machine={machine} />}
+    </div>
+  );
+}

--- a/components/machines/detail/stock/AddProductModal.tsx
+++ b/components/machines/detail/stock/AddProductModal.tsx
@@ -27,6 +27,8 @@ interface AddProductModalProps {
   open: boolean;
   onClose: () => void;
   onSuccess: () => void;
+  initialLine?: string;
+  initialSelection?: string;
 }
 
 export function AddProductModal({
@@ -34,13 +36,15 @@ export function AddProductModal({
   open,
   onClose,
   onSuccess,
+  initialLine,
+  initialSelection,
 }: AddProductModalProps) {
   const [products, setProducts] = useState<Product[]>([]);
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
   const [quantity, setQuantity] = useState(0);
   const [price, setPrice] = useState(0);
-  const [line, setLine] = useState("");
-  const [selection, setSelection] = useState("");
+  const [line, setLine] = useState(initialLine || "");
+  const [selection, setSelection] = useState(initialSelection || "");
 
   useEffect(() => {
     const fetchProducts = async () => {
@@ -51,8 +55,10 @@ export function AddProductModal({
 
     if (open) {
       fetchProducts();
+      setLine(initialLine || "");
+      setSelection(initialSelection || "");
     }
-  }, [open]);
+  }, [open, initialLine, initialSelection]);
 
   const handleProductSelect = (productId: string) => {
     const product = products.find((p) => p.id === productId);

--- a/components/machines/detail/stock/MachineStockTable.tsx
+++ b/components/machines/detail/stock/MachineStockTable.tsx
@@ -14,7 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { AddProductModal } from "@/components/machines/detail/stock/AddProductModal";
 import { AdjustStockModal } from "@/components/machines/detail/stock/AdjustStockModal";
-import { ChannelConfiguratorModal } from "@/components/machines/detail/stock/ChannelConfiguratorModal";
+import Link from "next/link";
 
 interface Props {
   machine: MachineWithProducts;
@@ -29,7 +29,6 @@ export function MachineStockTable({ machine }: Props) {
     null
   );
   const [selectedProductName, setSelectedProductName] = useState<string>("");
-  const [configOpen, setConfigOpen] = useState(false);
 
   useEffect(() => {
     setProducts(machine.products);
@@ -89,8 +88,8 @@ export function MachineStockTable({ machine }: Props) {
         >
           {deleteMode ? "Cancelar eliminar" : "Eliminar producto"}
         </Button>
-        <Button variant="secondary" onClick={() => setConfigOpen(true)}>
-          Configurar canales
+        <Button asChild variant="secondary">
+          <Link href={`/machines/${machine.id}/channels`}>Configurar canales</Link>
         </Button>
       </div>
 
@@ -184,13 +183,6 @@ export function MachineStockTable({ machine }: Props) {
         />
       )}
 
-      {configOpen && (
-        <ChannelConfiguratorModal
-          machine={{ ...machine, products }}
-          open={configOpen}
-          onClose={() => setConfigOpen(false)}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- move channel configuration to new page `/machines/[id]/channels`
- allow adding products directly from the grid
- show line, selection, stock, price and product
- link channel config from stock table

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685ad95eed108332a8ad9a2e4d9ac113