### PR TITLE
Show machine tabs in detail page

### DIFF
--- a/app/(routes)/machines/[id]/page.tsx
+++ b/app/(routes)/machines/[id]/page.tsx
@@ -5,7 +5,7 @@ import { EditMachineModal } from "@/components/machines/forms/EditMachineModal";
 import { Spinner } from "@/components/ui/spinner";
 import { toast } from "@/components/ui/use-toast";
 import { MachineWithDetails } from "@/types";
-//import { MachineDetailsTabs } from "@/components/machines/detail/MachineDetailsTabs";
+import { MachineDetailsTabs } from "@/components/machines/detail/MachineDetailsTabs";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -103,6 +103,8 @@ export default function MachineDetailPage({
           {/* Información básica de la máquina */}
           <MachineInfo machine={selectedMachine} onEdit={openEditModal} />
 
+          {/* Secciones de detalle: stock, mantenimiento, etc. */}
+          <MachineDetailsTabs machine={selectedMachine} />
 
           {/* Modal de edición */}
           <EditMachineModal


### PR DESCRIPTION
## Summary
- expose `MachineDetailsTabs` on the machine detail page so channel editing and stock information appear directly on the machine view

## Testing
- `npm test` *(fails: Cannot find module '/workspace/venderp/tests')*
- `node --test tests/apiResponses.test.js tests/spinner.test.js` *(fails: ERR_MODULE_NOT_FOUND)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0d0ee51483328df4058f119050ab